### PR TITLE
Use canonical oxlint schema URL

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "options": {
     "typeAware": true,
     "typeCheck": true


### PR DESCRIPTION
## Summary
- Replace the local `./node_modules/oxlint/configuration_schema.json` reference in `.oxlintrc.json` with the canonical GitHub raw URL.
- Functionally identical (IDE intellisense only) but the URL is portable across machines and matches the convention used in sibling repos.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run lint`
- [x] `bun run fmt:check`