### PR TITLE
Use ubuntu-latest for actions security workflow

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   actions-security:
     name: Check workflows
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- Change the Actions Security workflow runner from `ubuntu-24.04` to `ubuntu-latest`.

## Tests
- `git diff --check -- .github/workflows/actions-security.yml`